### PR TITLE
Places "warn" under "args" to get rid of error.

### DIFF
--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -24,7 +24,8 @@
 
   - name: Install NVM
     shell: "{{ run_command }} https://raw.githubusercontent.com/creationix/nvm/v{{ nvm_version }}/install.sh | NVM_SOURCE={{ nvm_source }} NVM_DIR={{ nvm_dir }} PROFILE={{ nvm_profile }} bash"
-    warn: false
+    args:
+      warn: false
     register: nvm_result
 
   when: "nvm_install == 'curl' or  nvm_install == 'wget'"


### PR DESCRIPTION
When attempting to run this role, you get errors about "warn" not being a valid attribute.  Placing it under "args" fixes this error.