### PR TITLE
Use installed node version

### DIFF
--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -76,6 +76,10 @@
   shell: bash -ic "nvm install {{ nodejs_version }}"
   when: "nvm_commands | length == 0"
 
+- name: Use Node if nvm_commands is empty
+  shell: bash -ic "nvm use {{ nodejs_version }}"
+  when: "nvm_commands | length == 0"
+
 - name: Install Node
   shell: bash -ic "{{item}}"
   with_items:


### PR DESCRIPTION
Currently, when installing a new version of node on a system that has had an existing version installed already, `nvm use` is not issued, which leads to the old version continuing to be used, even though the desired version is installed.