### PR TITLE
#21 Version check with default shell always being run regardless of valid shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,8 @@ Uninstall NVM, will remove .nvm directory and clean up `{{ nvm_profile }}` file
 None.
 
 ## Change Log
+**1.4.1**
+* Addressed version check as reported by [@DanHulton](https://github.com/morgangraphics/ansible-role-nvm/issues/21)
 
 **1.4.0**
 * Code Linting, Indempotency updates for CI/CD testing

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 #SEMVER
-role_version: "1.3.0"
+role_version: "1.4.1"
 
 role_repo: "https://github.com/morgangraphics/ansible-role-nvm"
 

--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -47,7 +47,7 @@
     - name: "!WARNING! set unrecommended default for any other nvm_profile value !WARNING!"
       set_fact:
         user_shell: { 'command': '/etc/bash -ic', 'alias': 'bash' }
-      when: (shell_path is undefined) or (found_path | bool == False)
+      when: (shell_path is undefined) or (found_path | length == 0)
 
     - name: does profile file exist
       stat:
@@ -217,4 +217,4 @@
       path: "{{ nvm_profile }}"
       state: absent
 
-  when: uninstall | bool == True
+  when: uninstall | bool


### PR DESCRIPTION
Ambiguity with `found_path | bool == False` is a little confusing as it was always running. Converted the check to the less ambiguous `found_path | length == 0` in addition to other variables doing something similar. 