### PR TITLE
Changed include to include_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: nvm.yml
+- ansible.builtin.include_tasks: nvm.yml


### PR DESCRIPTION
"include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16.