### PR TITLE
fix: use root for permission lock on nvm_profile

### DIFF
--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -108,6 +108,7 @@
       mode: 0644
       path: "{{ nvm_profile }}"
     become: true
+    become_user: root
     when: not profile_file.stat.exists
 
   when: nvm_install in ['curl', 'wget']


### PR DESCRIPTION
I'm trying to use the role, if i set the `become_user` the changed task fails with "file (.zshrc) is absent, cannot continue".

Changing the become_user  to root fixes the task.