### PR TITLE
switch from include to import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: nvm.yml
+- import_tasks: nvm.yml


### PR DESCRIPTION
When using this module on ansible 2.16.0 I get:

```
ERROR! [DEPRECATED]: ansible.builtin.include has been removed. Use include_tasks or import_tasks instead. This feature was removed from ansible-core in a release after 2023-05-16. Please update your playbooks.
```

Following https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse.html#imports-static-reuse , updating it to `import_tasks` seems to be the correct solution.