### PR TITLE
fix: replace include by import_tasks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,2 @@
 ---
-- include: nvm.yml
+- ansible.builtin.import_tasks: nvm.yml


### PR DESCRIPTION
Hi,

The `include` builtin has been removed in ansible-core 2.16 so this playbook does not work anymore.
This replaces it with `import_tasks`, not sure if it is better with `include_tasks` but import seems to be more widely used.