### PR TITLE
initial commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ You are attempting to run a version of Node.js on an operating system that is no
 
 **ansible-core 2.16 +**
 
-There has been a fundamental change on how Ansible manages includes. Ansible has removed `ansible.builtin.include_tasks` from ansible-core. Unfortunately, it cannot be scoped to ignore older versions etc. so I upgraded this role to fully support ansible-core 2.16+
+There has been a fundamental change on how Ansible manages includes/imports. Ansible has removed `ansible.builtin.include` from ansible-core and replaced it with `ansible.builtin.include_tasks`. Unfortunately, Ansible cannot scope `ansible.builtin.include` to ignore older versions etc. so I upgraded this role to fully support ansible-core 2.16+
 
 If you require support for ansible-core 2.15 and below, please use the [ansible-role-nvm-legacy](https://github.com/morgangraphics/ansible-role-nvm/tree/ansible-role-nvm-legacy) branch
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Ansible Role: NVM
 
 
-Installs NVM & Node.js on Debian/Ubuntu and RHEL/CentOS systems
-
+Installs NVM & Node.js on Debian/Ubuntu, RHEL/CentOS systems, and others *nix systems
 
 Ansible weirdness with SSH and (non)interactive shells makes working with NVM and Ansible a bit problematic. This [stack overflow](https://stackoverflow.com/questions/22256884/not-possible-to-source-bashrc-with-ansible) post explains some of the things other people have done to get around this particular issue.
 
@@ -23,6 +22,18 @@ Other Ansible roles that install NVM and/or Node.js fall short in a few areas.
 1.  You can install whatever **version** or **versions** of Node.js you want
 1.  Doesn't install NVM or Node.js as root
 1.  Can run arbitrary nvm, npm, node, bash or shell commands potentially eliminating the need for a separate Node Ansible role all together
+
+
+
+## Requirements
+
+Ansible version (ansible-core) 2.16.0 +
+
+
+> :triangular_flag_on_post: For a version of this role that works on older versions of Ansible see the [legacy 1.5.X branch](https://github.com/morgangraphics/ansible-role-nvm/tree/ansible-role-nvm-legacy)
+
+See [Ansible Versions below](#ansible-versions)
+
 
 ## Installation
 1.  Clone this repo into your roles folder
@@ -86,7 +97,7 @@ BEST :metal:
       nvm_commands:
        - "nvm exec default npm install"
       become: true            # THIS WILL CHANGE THE LOGIN CONTEXT TO USE THE USER BELOW
-      become_user: ec2-user   # THIS INSTALLS NVM IN THE CONTEXT OF THE EC2-USER/DEFAULT USER
+      become_user: ec2-user   # THIS INSTALLS NVM IN THE CONTEXT OF THE EC2-USER/DEFAULT USER. THIS USER MUST EXIST ON THE SYSTEM!
 
     - role: some-other-role
       ...
@@ -96,7 +107,6 @@ BEST :metal:
 
 See [Issues](#issues) below for further details
 
----
 
 ## Example Playbooks
 
@@ -323,6 +333,7 @@ Another example
         - "node --version"
         - "nvm --version"
         - "npm --version"
+        - "python3 -m hello"
       become_user: test-user
       become: true
 ```
@@ -341,13 +352,13 @@ Another example
 ## Issues
 
 
-#### `"nvm: command not found" error`
+### `"nvm: command not found" error`
 
 This is often the result of running the role in another user context then the `nvm` and `node` user context will run inside the machine. If you add `become: true` to all the roles in your playbook to get around errors those roles throw due to permission issues, then this role will install `nvm` under the `ROOT_USER` (usually `/root/.bashrc`). **It is more than likely that you will want to run nvm and node as a default user e.g. vagrant, ec2-user, ubuntu etc.** If, for whatever reason, you cannot remove the `become: true` for everything, you can get around the `become: true` issue by specifying `become: true` **AND** `become_user: ec2-user` for this role alone. See [bash: nvm command not found
 ](https://github.com/morgangraphics/ansible-role-nvm/issues/16) for a detailed explanation of the issue
 
 
-#### `"cannot find /usr/bin/python" error`
+### `"cannot find /usr/bin/python" error`
 
 It is due to OS's that run Python 3 by default (e.g. Fedora). You will need to specify the Ansible python interpreter variable in the inventory file or via the command line
 
@@ -368,24 +379,33 @@ or
 ansible-playbook my-playbook.yml -e "ansible_python_interpreter=/usr/bin/python3"
 ```
 
----
-## Ansible Versions
+### `glibc_2.28' not found (required by node)`
 
-Ansible versions prior to 7 (ansible-core 2.14) had the ability to suppress deprecation warnings at the task level e.g
+You are attempting to run a version of Node.js on an operating system that is not supported by the version of Node.js you are installing. This is not an NVM issue nor is it an issue with the role. You need to either upgrade the OS or downgrade the version of Node.js you are atrempting to install. 
 
-```yaml
-  - name: Some Task
-    shell: "<SOME COMMAND>"
-    args:
-      warn: false
-```
 
-This feature has been removed in Ansible version 7.
+<a name="ansible-versions"></a>
 
 ---
+## Ansible Version Support
+
+**ansible-core 2.16 +**
+
+There has been a fundamental change on how Ansible manages includes. Ansible has removed `ansible.builtin.include_tasks` from ansible-core. Unfortunately, it cannot be scoped to ignore older versions etc. so I upgraded this role to fully support ansible-core 2.16+
+
+If you require support for ansible-core 2.15 and below, please use the [ansible-role-nvm-legacy](https://github.com/morgangraphics/ansible-role-nvm/tree/ansible-role-nvm-legacy) branch
+
+**ansible-core 2.15 and below**
+
+Please use the [legacy 1.5.X branch](https://github.com/morgangraphics/ansible-role-nvm/tree/ansible-role-nvm-legacy)
+
+
+
 ## Role Variables
 
 Available variables are listed below, along with default values see [defaults/main.yml]( defaults/main.yml)
+
+
 
 The Node.js version to install. The latest "lts" version is the default and works on most supported OSes.
 
@@ -393,20 +413,32 @@ The Node.js version to install. The latest "lts" version is the default and work
   nodejs_version: "lts"
   ```
 
-Convenience method for installing NVM bash autocomplete (`nvm <TAB>`) when a user has to maintain a server or workstation manually
+ Convenience method for installing NVM bash autocomplete (`nvm <TAB>`) when a user has to maintain a server or workstation manually
 
   ```yaml
   autocomplete: false
   ```
 
-Set default version of Node when maintaining/installing multiple versions
+Install NVM from scratch removing **ANY** and **ALL** existing or previous references to `.nvm` (directories) and **ANY** and **ALL** existing or previous references in profile entries e.g. `.bashrc` in the system. 
 
+```yaml
+clean_install: false
+```
+
+> `clean_install: true` greps all files in `/home` `/root`, `/etc`, and `custom install directories` for refrences as-well-as looking for any `.nvm` folder in the system. This is equivalent to a new machine setup, **USE WITH CAUTION**
+
+
+```yaml
 default: false
+```
+
+Set default version of Node when maintaining/installing multiple versions of Node
+
 
 > NVM will automatically alias the first run/installed version as "default" which is more than likely what people will use this role  for, however, this will allow for installation/upgrade of multiple versions on an existing machine
 
 
-List of [NVM commands to run](https://github.com/creationix/nvm#usage). Default is an empty list.
+List of [NVM commands to run](#nvm-commands). Default is an empty list.
 
   ```yaml
   nvm_commands: []
@@ -416,7 +448,7 @@ NVM Installation type. Options are wget, curl and git
 
   ```yaml
   nvm_install: "wget"
-  ````
+  ```
 
 NVM Installation directory.
 
@@ -432,14 +464,19 @@ NVM Profile location Options are .bashrc, .cshrc, .tcshrc, .zshrc
   nvm_profile: ".bashrc"
   ```
 
-> The location of the SHELL profile that will source the nvm command from. There are two potential contexts to consider,
-> globally, meaning everyone who logs in will have access to nvm (which may or may not what you really want)
-> e.g **/etc/bash.bashrc**, **/etc/profile**, etc.
+> The location of the login SHELL profile that will source the nvm command from. There are two potential contexts to consider:
+>
+> *Globally, meaning everyone who logs in will have access to nvm (which may or may not what you really want)*
+>
+> e.g `/etc/bash.bashrc`, `/etc/profile` etc.
 >
 > **OR**
 >
-> *On a per user basis tied to a specific user account e.g. /home/vagrant/.bashrc.*
->  *This role will create the appropriate profile file if it doesn't already exist.*
+> *On a per user basis tied to a specific user account*
+>
+> e.g. `/home/vagrant/.bashrc`.*
+> 
+> *This role will create the appropriate profile file if it doesn't already exist.*
 >
 > *If you specify nvm_profile: "/home/node-user/.bashrc" explicity and the node-user is not a real  user on the box, then nvm will not work as you expect. become, become_user and nvm_profile path are symbiotic*
 >
@@ -469,10 +506,10 @@ NVM source location i.e. you host your own fork of [NVM](https://github.com/crea
 NVM version to install
 
   ```yaml
-  nvm_version: "0.39.3"
+  nvm_version: "0.39.7"
   ```
 
-Uninstall NVM, will remove .nvm directory and clean up `{{ nvm_profile }}` file
+Uninstall NVM, will remove the .nvm directory and clean up file located at the `{{ nvm_profile }}` variable path (usually $HOME/.bashrc) where ever that file is located
 
   ```yaml
   uninstall: False
@@ -487,64 +524,10 @@ None.
 
 ## Change Log
 ---
-**1.5.2**
-* [@neutralalice](https://github.com/morgangraphics/ansible-role-nvm/issues/41) reported issue with connection=local issues
-* NVM Version update
-* Comment in example to make things more clear about users needed to exist on the system before installation
+**2.0.0**
+See the [RELEASE NOTES]()
 
-**1.5.1**
-* [@otsuka](https://github.com/morgangraphics/ansible-role-nvm/issues/39) reported issue with version numbering mismatch
-* Removed travis cd yaml file. Moving to CircleCI eventually
-* Fixed some things in meta/main.yaml file
 
-**1.5.0**
-*   [@dandelany](https://github.com/morgangraphics/ansible-role-nvm/issues/35) reported an issue regarding the now deprecated `warn: false`
-* [#36 default:true is not idempotent](https://github.com/morgangraphics/ansible-role-nvm/issues/36) was fixed while testing `warn: false` issue
-* Internal variable names changes to group them under a common prefix
-* Default dash command check was missing
-* NVM Version bump
-
-**1.4.3**
-*   NVM Version bump, Ansible Galaxy_Tags, README.md linting
-
-**1.4.2**
-*   Updated documentation to fix missing `become: true` when using `become_user: some-user` as reported by  [@jfoliveira](https://github.com/morgangraphics/ansible-role-nvm/issues/23)
-
-**1.4.1**
-*   Addressed version check as reported by [@DanHulton](https://github.com/morgangraphics/ansible-role-nvm/issues/21)
-
-**1.4.0**
-*   Code Linting, Indempotency updates for CI/CD testing
-*   Addressed version check as reported by [@Jamesking56](https://github.com/morgangraphics/ansible-role-nvm/issues/18)
-
-**1.3.0**
-*   Addressed `nvm: command not found error` bug as reported by [@eyekelly](https://github.com/morgangraphics/ansible-role-nvm/issues/16).
-*   Updated documentation in greater detail about user context/session/shells to guard against `nvm: command not found error`.
-*   Updated default variable explanations
-*   Reworked documentation and examples surrounding `nvm_commands`
-*   NVM version bump
-
-**1.2.2**
-*   NVM version bump
-
-**1.2.1**
-*   Documentation updates for clarity
-
-**1.2.0**
-*   Addresses issues [#8 Add default: True role variable to ensure NVM default alias is set correctly](https://github.com/morgangraphics/ansible-role-nvm/issues/8), [#9 Git functionality has changed according to the NVM documentation](https://github.com/morgangraphics/ansible-role-nvm/issues/9), [#10 NVM has an Autocomplete functionality. Add `autocomplete: True` Ansible variable to role](https://github.com/morgangraphics/ansible-role-nvm/issues/10), [#11 Update documentation to highlight updating a default version](https://github.com/morgangraphics/ansible-role-nvm/issues/11), and [#12 Add remove: True variable to uninstall NVM](https://github.com/morgangraphics/ansible-role-nvm/issues/12) as discussed with [@DanHulton](https://github.com/morgangraphics/ansible-role-nvm/pull/7) to address multiple version of Node.js running on the same host.
-*   Expanded documentation with examples about how powerful `nvm_commands: []` can be
-
-**1.1.2**
-*   Issue reported/PR supplied by [@DanHulton](https://github.com/morgangraphics/ansible-role-nvm/pull/5), Documentation updates,
-
-**1.1.1**
-*   Documentation updates
-
-**1.1.0**
-*   Issue reported by [@magick93](https://github.com/morgangraphics/ansible-role-nvm/issues/3), Bumped default version of NVM script, Documentation updates
-
-**1.0.2**
-*   Issue reported by [@swoodford](https://github.com/morgangraphics/ansible-role-nvm/issues/1), Bumped default version of NVM script, Documentation updates
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 #SEMVER
-role_version: "1.5.2"
+role_version: "2.0.0"
 
 role_repo: "https://github.com/morgangraphics/ansible-role-nvm"
 
@@ -13,11 +13,19 @@ nodejs_version: "lts"
 # but only works when a human logs into said machine. More of a convienence method for this role
 autocomplete: false
 
+# Install NVM from scratch removing any and all references to it.
+# This greps all files in /home /root and /etc for refrences as well as
+# looking for any folder with nvm in it
+clean_install: false
+
 # NVM will automatically alias First Run version as default which is more than likely
 # what people will use this for This will allow for installation/upgrade of multiple versions on an existing
 # machine for the scenarios described in
 # https://github.com/morgangraphics/ansible-role-nvm/pull/7#issuecomment-481423099
 default: false
+
+# AdHoc NVM Commands
+nvm_commands: []
 
 # The next 3 options only apply to wget and curl - If you don't know what you're doing
 # you are fine to leave these alone.
@@ -28,9 +36,6 @@ default: false
 # global space (meaning not tied to a specific user account) if you wanted. This variable will respect
 # Ansible substitution variables e.g. nvm_dir: "{{ansible_env.HOME}}/.nvm"
 nvm_dir: ""
-
-# AdHoc NVM Commands
-nvm_commands: []
 
 # Options are wget, curl, git
 # Git :default dest: is the same as nvm_profile below.
@@ -66,7 +71,7 @@ nvm_profile: "~/.bashrc"
 nvm_source: ""
 
 # Version of NVM to install
-nvm_version: "0.39.5"
+nvm_version: "0.39.7"
 
 # Uninstall NVM
 uninstall: false

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: NVM installation for Linux
   company: "MORGANGRAPHICS"
   license: "license (BSD, MIT)"
-  min_ansible_version: "2.0"
+  min_ansible_version: "2.16.0"
   platforms:
     - name: EL
       versions:
@@ -19,6 +19,7 @@ galaxy_info:
       - all
     - name: Ubuntu
       versions:
+      - jammy
       - focal
       - bionic
       - xenial

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
-- include: nvm.yml
+
+- ansible.builtin.include_tasks: nvm.yml

--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -1,16 +1,53 @@
 ---
 
+# testing for who is running the playbook to be able to intelligently associate
+# a user when installing in a protected directory like /opt/nvm.
+# WARNING!! This only makes it available to that specific user and not people associated
+# with a group see https://github.com/morgangraphics/ansible-role-nvm/issues/26
+- name: "Who is running this playbook?"
+  ansible.builtin.command: whoami
+  register: mg_nvm_whoami
+  changed_when: false
+
+- name: Set a fact with the user name running the playbook.
+  ansible.builtin.set_fact:
+    mg_login_user: "{{ mg_nvm_whoami.stdout }}"
+
+- name: Set full nvm_profile path | Default
+  ansible.builtin.set_fact:
+    nvm_profile: "$HOME/.bashrc"
+  when: nvm_profile == '.bashrc'
+
+- name: Set full nvm_profile path | Custom Path
+  ansible.builtin.set_fact:
+    nvm_profile: "{{ nvm_profile }}"
+  when: nvm_profile != '.bashrc'
+
+# ERROR HANDLING
+- name: test to ensure symbiotic variables are declared | nvm_dir AND nvm_profile
+  ansible.builtin.fail:
+    msg: "If setting a custom nvm_dir directory e.g. /opt/nvm, nvm_dir MUST be used in combination with nvm_profile"
+  when: nvm_dir and nvm_profile == '.bashrc' and nvm_install != 'git'
+
+- name: test to ensure symbiotic variables are declared | nvm_dir AND nvm_install = git
+  ansible.builtin.fail:
+    msg: "If installing via GIT nvm_install: git MUST be used in combination with nvm_dir and include the full path e.g. nvm_dir: '$HOME/.nvm'"
+  when: not nvm_dir and nvm_install == 'git'
+
+
+# ENVIRONMENT SHELL TESTING
+
 # https://github.com/morgangraphics/ansible-role-nvm/issues/18
 - name: determine shell in which we are running
   block:
 
     - name: set default found path
-      set_fact:
+      ansible.builtin.set_fact:
         mg_found_path: ''
 
     - name: test for shells
-      command: "which {{ item }}"
-      with_items:
+      ansible.builtin.command: "which {{ item }}"
+      loop:
         - bash
         - dash
         - zsh
@@ -21,47 +58,47 @@
       changed_when: "mg_shell_path.rc != 0"
 
     - name: set found path
-      set_fact:
+      ansible.builtin.set_fact:
         mg_found_path: "{{ mg_shell_path.results | selectattr('stdout', 'defined') | map(attribute = 'stdout') | list | first }}"
       when: mg_shell_path.results | selectattr('stdout', 'defined') | map(attribute = 'stdout') | list | length > 0
 
     - name: set bash command
-      set_fact:
+      ansible.builtin.set_fact:
         mg_user_shell: { 'command': '{{ mg_found_path }} -ic', 'alias': 'bash' }
       when: '"bash" in nvm_profile'
 
     - name: set dash command
-      set_fact:
+      ansible.builtin.set_fact:
         mg_user_shell: { 'command': '{{ mg_found_path }} -ic', 'alias': 'dash' }
       when: '"dash" in nvm_profile'
 
     - name: set zsh command
-      set_fact:
+      ansible.builtin.set_fact:
         mg_user_shell: { 'command': '{{ mg_found_path }} -ic', 'alias': 'zsh' }
       when: '"zsh" in nvm_profile'
 
     - name: set csh command
-      set_fact:
+      ansible.builtin.set_fact:
         mg_user_shell: { 'command': '{{ mg_found_path }} -ic', 'alias': 'csh' }
       when: "'csh' in nvm_profile and 'tcsh' not in nvm_profile"
 
     - name: set tcsh command
-      set_fact:
+      ansible.builtin.set_fact:
         mg_user_shell: { 'command': '{{ mg_found_path }} -ic', 'alias': 'tcsh' }
       when: "'tcsh' in nvm_profile"
 
     - name: "!WARNING! set unrecommended default for any other nvm_profile value !WARNING!"
-      set_fact:
+      ansible.builtin.set_fact:
         mg_user_shell: { 'command': '/etc/bash -ic', 'alias': 'bash' }
       when: (mg_shell_path is undefined) or (mg_found_path | length == 0)
 
     - name: does profile file exist
-      stat:
+      ansible.builtin.stat:
         path: "{{ nvm_profile }}"
       register: mg_profile_file
 
     - name: Create profile file if it does not exist
-      file:
+      ansible.builtin.file:
         group: "{{ ansible_become_user | default(ansible_user) }}"
         owner: "{{ ansible_become_user | default(ansible_user) }}"
         mode: 0777
@@ -72,166 +109,163 @@
 
   when: nvm_profile | length != 0
 
-# wget (deault) or curl
-- name: Installing via curl or wget
+
+# UNINSTALL
+- ansible.builtin.import_tasks: uninstall.yml
+
+# I don't want the rest of the playbook running when uninstall = true 
+# It defeats the purpose of the uninstall in the first place
+- name: Run everything else when uninstall = false
   block:
-  - name: Check if wget or curl is installed
-    command: "which {{ nvm_install }}"
-    register: mg_cmd
-    changed_when: "mg_cmd.rc != 0"
 
-  - name: Determine if install type wget
-    set_fact:
-      run_command: 'wget -qO-'
-    when: "'/wget' in mg_cmd.stdout"
+    # wget (deault) or curl
+    - name: Installing via curl or wget
+      block:
+      - name: Check if wget or curl is installed
+        ansible.builtin.command: "which {{ nvm_install }}"
+        register: mg_cmd
+        changed_when: "mg_cmd.rc != 0"
 
-  - name: Determine if install type curl
-    set_fact:
-      run_command: 'curl -o-'
-    when: "'/curl' in mg_cmd.stdout"
+      - name: Determine if install type wget
+        ansible.builtin.set_fact:
+          run_command: 'wget -qO-'
+        when: "'/wget' in mg_cmd.stdout"
 
-  - name: Create nvm_dir if it does not exist
-    file:
-      group: "{{ ansible_become_user | default(ansible_user) }}"
-      owner: "{{ ansible_become_user | default(ansible_user) }}"
-      mode: 0775
-      path: "{{ nvm_dir }}"
-      state: directory
-    become: true
-    when: nvm_dir | length != 0
+      - name: Determine if install type curl
+        ansible.builtin.set_fact:
+          run_command: 'curl -o-'
+        when: "'/curl' in mg_cmd.stdout"
 
-  # There are some potential security concerns with piping the install.sh script to whatever shell alias is defined: Risk is Low but not absolute
-  # https://blog.dijit.sh//don-t-pipe-curl-to-bash
-  # https://news.ycombinator.com/item?id=12766049
-  # https://sandstorm.io/news/2015-09-24-is-curl-bash-insecure-pgp-verified-install
-  - name: Install NVM
-    shell: "{{ run_command }} https://raw.githubusercontent.com/creationix/nvm/v{{ nvm_version }}/install.sh | NVM_SOURCE={{ nvm_source }} NVM_DIR={{ nvm_dir }} PROFILE={{ nvm_profile }} {{ mg_user_shell.alias }}"
-    register: mg_nvm_result
-    changed_when: "'already installed' not in mg_nvm_result.stdout"
-    failed_when:
-      - "'permission denied' in mg_nvm_result.stderr"
+      - name: Create nvm_dir if it does not exist
+        ansible.builtin.file:
+          group: "{{ ansible_become_user | default(ansible_user) }}"
+          owner: "{{ ansible_become_user | default(ansible_user) }}"
+          mode: 0775
+          path: "{{ nvm_dir }}"
+          state: directory
+        become: true
+        when: nvm_dir | length != 0
 
-  - name: Update profile permissions to lock it down after writing
-    file:
-      group: "{{ ansible_become_user | default(ansible_user) }}"
-      owner: "{{ ansible_become_user | default(ansible_user) }}"
-      mode: 0644
-      path: "{{ nvm_profile }}"
-    become: true
-    when: not mg_profile_file.stat.exists
+      # There are some potential security concerns with piping the install.sh script to whatever shell alias is defined: Risk is Low but not absolute
+      # https://blog.dijit.sh//don-t-pipe-curl-to-bash
+      # https://news.ycombinator.com/item?id=12766049
+      # https://sandstorm.io/news/2015-09-24-is-curl-bash-insecure-pgp-verified-install
+      - name: Install NVM
+        ansible.builtin.shell: "{{ run_command }} https://raw.githubusercontent.com/creationix/nvm/v{{ nvm_version }}/install.sh | NVM_SOURCE={{ nvm_source }} NVM_DIR={{ nvm_dir }} PROFILE={{ nvm_profile }} {{ mg_user_shell.alias }}"
+        register: mg_nvm_result
+        changed_when: "'already installed' not in mg_nvm_result.stdout"
+        failed_when:
+          - "'permission denied' in mg_nvm_result.stderr"
 
-  when: nvm_install in ['curl', 'wget']
+      - name: Update profile permissions to lock it down after writing
+        ansible.builtin.file:
+          group: "{{ ansible_become_user | default(ansible_user) }}"
+          owner: "{{ ansible_become_user | default(ansible_user) }}"
+          mode: 0644
+          path: "{{ nvm_profile }}"
+        become: true
+        when: not mg_profile_file.stat.exists
 
+      when: nvm_install in ['curl', 'wget']
 
-# git
-- name: install via git
-  block:
-    - name: Check if git is installed
-      command: "which {{ nvm_install }}"
-      register: mg_cmd
+    # git
+    - name: install via git
+      block:
+        - name: Check if git is installed
+          ansible.builtin.command: "which {{ nvm_install }}"
+          register: mg_cmd
 
-    - name: Remove NVM nvm_profile
-      blockinfile:
+        - name: Remove NVM nvm_profile
+          ansible.builtin.blockinfile:
+            block: |
+              export NVM_DIR="$HOME/.nvm"
+              [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+            marker_begin: "Installed via {{ role_repo }} START"
+            marker_end: "{{ role_repo }} END"
+            path: "{{ nvm_profile }}"
+            state: absent
+
+        - name: Install via git
+          ansible.builtin.git:
+            dest: "{{ nvm_dir }}"
+            repo: 'https://github.com/creationix/nvm.git .nvm'
+            version: "{{ nvm_version }}"
+          when: "'/git' in mg_cmd.stdout"
+
+        - name: Add NVM to nvm_profile
+          ansible.builtin.blockinfile:
+            block: |
+              export NVM_DIR="$HOME/.nvm"
+              [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
+            create: yes
+            marker_begin: "Installed nvm via {{ role_repo }} START"
+            marker_end: "{{ role_repo }} END"
+            mode: 0644
+            path: "{{ nvm_profile }}"
+            state: present
+
+      when: "nvm_install == 'git'"
+
+    - name: Check NVM Version # noqa 305
+      ansible.builtin.shell: "{{ mg_user_shell.command + ' \"nvm --version\"' }}"
+      register: mg_nvm_version_response
+      changed_when: "mg_nvm_version_response.rc != 0"
+
+    # Autocomplete
+    - name: Add NVM autocomplete to nvm_profile
+      ansible.builtin.blockinfile:
         block: |
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
-        marker_begin: "Installed via {{ role_repo }} START"
-        marker_end: "{{ role_repo }} END"
-        path: "{{ nvm_profile }}"
-        state: absent
-
-    - name: Install via git
-      git:
-        dest: "{{ nvm_dir }}"
-        repo: 'https://github.com/creationix/nvm.git .nvm'
-        version: "{{ nvm_version }}"
-      when: "'/git' in mg_cmd.stdout"
-
-    - name: Add NVM to nvm_profile
-      blockinfile:
-        block: |
-          export NVM_DIR="$HOME/.nvm"
-          [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" # This loads nvm
-        create: yes
-        marker_begin: "Installed nvm via {{ role_repo }} START"
+          [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+        insertafter: "# This loads nvm"
+        marker_begin: "Installed nvm autocomplete via {{ role_repo }} START"
         marker_end: "{{ role_repo }} END"
         mode: 0644
         path: "{{ nvm_profile }}"
         state: present
+      when: autocomplete
 
-  when: "nvm_install == 'git'"
+    - name: LTS Check
+      ansible.builtin.set_fact:
+        nodejs_version: --lts
+        nodejs_alias: lts/*
+      when: "nodejs_version == 'lts'"
 
-- name: Check NVM Version # noqa 305
-  shell: "{{ mg_user_shell.command + ' \"nvm --version\"' }}"
-  register: mg_nvm_version_response
-  changed_when: "mg_nvm_version_response.rc != 0"
+    # This scenario handles the first run/install of NVM because this will automatically
+    # alias the specified version as default - This should handle most use cases
+    - name: Install Node # noqa 305
+      ansible.builtin.shell: "{{ mg_user_shell.command + ' \"nvm install ' +  nodejs_version + '\"' }}"
+      register: mg_node_version_response
+      changed_when: "'already installed' not in mg_node_version_response.stderr"
 
-# Autocomplete
-- name: Add NVM autocomplete to nvm_profile
-  blockinfile:
-    block: |
-      [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-    insertafter: "# This loads nvm"
-    marker_begin: "Installed nvm autocomplete via {{ role_repo }} START"
-    marker_end: "{{ role_repo }} END"
-    mode: 0644
-    path: "{{ nvm_profile }}"
-    state: present
-  when: autocomplete
+    # Test is there is a default already set
+    - name: Is there a default already set # noqa 305
+      ansible.builtin.shell: "{{ mg_user_shell.command + ' \"cat \\$(printenv NVM_DIR)/alias/default\"' }}"
+      register: mg_nvm_default_response
+      changed_when: "mg_nvm_default_response.rc != 0"
 
-- name: LTS Check
-  set_fact:
-    nodejs_version: --lts
-  when: "nodejs_version == 'lts'"
+    # In the event there are multiple versions of Node being installed/used/upgraded
+    # on the same machine we'll need to alias the default version accordingly
+    - name: Set default version of Node if multiple versions exist # noqa 305
+      ansible.builtin.shell: "{{ mg_user_shell.command + ' \"nvm alias default ' +  nodejs_version + '\"' }}"
+      when:  
+      - default | bool
+      - nodejs_version != '--lts'
+      changed_when: "'nodejs_version' not in mg_nvm_default_response.stdout"
 
-# This scenario handles the first run/install of NVM because this will automatically
-# alias the specified version as default - This should handle most use cases
-- name: Install Node # noqa 305
-  shell: "{{ mg_user_shell.command + ' \"nvm install ' +  nodejs_version + '\"' }}"
-  register: mg_node_version_response
-  changed_when: "'already installed' not in mg_node_version_response.stderr"
+    # Addresses an issue where the LTS version is set as a default. The version above 
+    # doesn't work because --lts is not an alias, according to nvm documentation it is lts/*
+    - name: Set default version of Node LTS if multiple versions exist # noqa 305
+      ansible.builtin.shell: "{{ mg_user_shell.command + ' \"nvm alias default ' +  nodejs_alias + '\"' }}"
+      when: 
+      - default | bool
+      - nodejs_version == '--lts'
+      changed_when: "'nodejs_version' not in mg_nvm_default_response.stdout"
 
-# Test is there is a default already set
-- name: Is there a default already set # noqa 305
-  shell: "{{ mg_user_shell.command + ' \"cat \\$(printenv NVM_DIR)/alias/default\"' }}"
-  register: mg_nvm_default_response
-  changed_when: "mg_nvm_default_response.rc != 0"
-
-# In the event there are multiple versions of Node being installed/used/upgraded
-# on the same machine we'll need to alias the default version accordingly
-- name: Set default version of Node if multiple versions exist # noqa 305
-  shell: "{{ mg_user_shell.command + ' \"nvm alias default ' +  nodejs_version + ' --no-colors\"' }}"
-  when:  default
-  changed_when: "'nodejs_version' not in mg_nvm_default_response.stdout"
-
-- name: Run whatever nvm_commands are there # noqa 305
-  shell: "{{ mg_user_shell.command + ' \"' +  item + '\"' }}"
-  with_items:
-    "{{ nvm_commands }}"
-  when: nvm_commands | length > 0
-
-# Uninstall NVM
-- name: uninstall nvm
-  block:
-
-  - name: Uninstall NVM
-    file:
-      path: "{{ lookup('env','NVM_DIR') }}"
-      state: absent
-
-  - name: Remove NVM nvm_profile info
-    lineinfile:
-      regexp: '^export.+nvm\"|\[.+nvm'
-      path: "{{ nvm_profile }}"
-      state: absent
-
-  - name: Remove NVM autocomplete from nvm_profile
-    blockinfile:
-      block: |
-        [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-      marker_begin: "Installed via {{ role_repo }} START"
-      marker_end: "{{ role_repo }} END"
-      path: "{{ nvm_profile }}"
-      state: absent
-
-  when: uninstall | bool
+    - name: Run whatever nvm_commands are there # noqa 305
+      ansible.builtin.shell: "{{ mg_user_shell.command + ' \"' +  item + '\"' }}"
+      register: mg_nvm_commands_response
+      loop:
+        "{{ nvm_commands }}"
+      when: nvm_commands | length > 0
+      
+  when: not uninstall

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,0 +1,84 @@
+---
+
+  - name: uninstall
+    block:
+
+      - name: find .nvm path
+        ansible.builtin.shell: "{{ mg_user_shell.command }} + ' printenv NVM_DIR'"
+        register: mg_remote_nvm_path
+        changed_when: "mg_remote_nvm_path.rc != 0"
+
+      - name: Uninstall NVM
+        ansible.builtin.file:
+          path: "{{ mg_remote_nvm_path.stdout | default('~/.nvm') }}"
+          state: absent
+
+      - name: Remove NVM nvm_profile info
+        ansible.builtin.lineinfile:
+          regexp: '^export.+nvm\"|\[.+nvm'
+          path: "{{ nvm_profile }}"
+          state: absent
+
+      - name: Remove NVM autocomplete from nvm_profile
+        ansible.builtin.blockinfile:
+          block: |
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+          marker_begin: "Installed via {{ role_repo }} START"
+          marker_end: "{{ role_repo }} END"
+          path: "{{ nvm_profile }}"
+          state: absent
+
+    when: uninstall or clean_install
+
+
+  - name: clean_install
+    block:
+
+      # find any directory that has nvm in it e.g. /.nvm or /nvm etc. 
+      # exclude any path that contains linux
+      # ignore anything that has "Permission denied" in the response and then
+      # direct it to stdout >&1
+      # if there is a match force the correct .rc code e.g. .rc = 0
+      # ignore_errors is there for when there is no match and the wrong .rc code is returned
+      - name: check folders that match nvm
+        ansible.builtin.raw: "find / -type d -not \\( -path **/linux** -prune \\) -regex '.*/.nvm' 2>&1 | { grep -v \"Permission denied\" >&1; [ $? -eq 0 ]; }"
+        register: nvm_dir_possible_locations
+        ignore_errors: true
+        changed_when:
+          - "'Shared connection' in nvm_dir_possible_locations.stderr"
+          - nvm_dir_possible_locations.stdout_lines | length > 0
+        failed_when: "'Shared connection' not in nvm_dir_possible_locations.stderr"
+
+      # remove any directories that match
+      - name: Uninstall NVM directory
+        ansible.builtin.file:
+          path: "{{ item }}"
+          state: absent
+        loop: "{{ nvm_dir_possible_locations.stdout_lines }}"
+        when: nvm_dir_possible_locations.stdout_lines | length > 0
+    
+      # r = recursive
+      # w = word-regex Select only those lines containing matches that form whole words.
+      # s = suppress error messages (no "Permission Denied")
+      # l = files with matches (just the path)
+      # I = ignore binary files
+      # -- we will look for NVM in the normal places
+      # ignore_errors is there for when there is no match and the wrong .rc code is returned
+      - name: check files in /home, /etc and /root custom_nvm_directory and custom nvm_profile for nvm related stuff
+        ansible.builtin.raw: "grep -rwslI -E \"^export.+nvm|\\[.+nvm(\\sbash_completion)?\" /home /etc /root {{ nvm_dir }} {{ nvm_profile }} --include=.*{shrc,profile} >&1; [ $? -eq 0 ];"
+        register: nvm_shell_possible_locations
+        ignore_errors: true
+        changed_when:
+          - "'Shared connection' in nvm_shell_possible_locations.stderr"
+          - nvm_shell_possible_locations.stdout_lines | length > 0
+        failed_when: "'Shared connection' not in nvm_shell_possible_locations.stderr"
+
+      - name: Remove NVM nvm_profile info
+        ansible.builtin.lineinfile:
+          regexp: '^export.+nvm\"|\[.+nvm(\sbash_completion)?'
+          path: "{{ item }}"
+          state: absent
+        loop: "{{ nvm_shell_possible_locations.stdout_lines }}"
+        when: nvm_shell_possible_locations.stdout_lines | length > 0
+    
+    when: clean_install | bool


### PR DESCRIPTION
As reported by @danfoster and @legau Ansible-core 2.16 removed `ansible.builtin.include` from ansible-core and replaced it with `ansible.builtin.include_tasks`. Ansible cannot scope `ansible.builtin.include` to ignore older versions etc. so I upgraded this role to fully support ansible-core 2.16+
All legacy modules/plugins declarations have been updated to the newer  `ansible.builtin` module/plugin declarations
`with_items` declarations were replaced with `loop` declarations
Error handling was added on symbiotic role variables
Uninstall was moved to another file
`clean_install` variable and functionality were added to really remove things if needed 
Added a task related to the scenario where a LTS version is set explicitly with `default: true`. 
Updated README.md file with some fixes and formatting and references
