### PR TITLE
Fixes installations in shells other than bash

### DIFF
--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -113,7 +113,7 @@
 # UNINSTALL
 - ansible.builtin.import_tasks: uninstall.yml
 
-# I don't want the rest of the playbook running when uninstall = true 
+# I don't want the rest of the playbook running when uninstall = true
 # It defeats the purpose of the uninstall in the first place
 - name: Run everything else when uninstall = false
   block:
@@ -151,7 +151,7 @@
       # https://news.ycombinator.com/item?id=12766049
       # https://sandstorm.io/news/2015-09-24-is-curl-bash-insecure-pgp-verified-install
       - name: Install NVM
-        ansible.builtin.shell: "{{ run_command }} https://raw.githubusercontent.com/creationix/nvm/v{{ nvm_version }}/install.sh | NVM_SOURCE={{ nvm_source }} NVM_DIR={{ nvm_dir }} PROFILE={{ nvm_profile }} {{ mg_user_shell.alias }}"
+        ansible.builtin.shell: "{{ run_command }} https://raw.githubusercontent.com/creationix/nvm/v{{ nvm_version }}/install.sh | NVM_SOURCE={{ nvm_source }} NVM_DIR={{ nvm_dir }} PROFILE={{ nvm_profile }} bash"
         register: mg_nvm_result
         changed_when: "'already installed' not in mg_nvm_result.stdout"
         failed_when:
@@ -247,16 +247,16 @@
     # on the same machine we'll need to alias the default version accordingly
     - name: Set default version of Node if multiple versions exist # noqa 305
       ansible.builtin.shell: "{{ mg_user_shell.command + ' \"nvm alias default ' +  nodejs_version + '\"' }}"
-      when:  
+      when:
       - default | bool
       - nodejs_version != '--lts'
       changed_when: "'nodejs_version' not in mg_nvm_default_response.stdout"
 
-    # Addresses an issue where the LTS version is set as a default. The version above 
+    # Addresses an issue where the LTS version is set as a default. The version above
     # doesn't work because --lts is not an alias, according to nvm documentation it is lts/*
     - name: Set default version of Node LTS if multiple versions exist # noqa 305
       ansible.builtin.shell: "{{ mg_user_shell.command + ' \"nvm alias default ' +  nodejs_alias + '\"' }}"
-      when: 
+      when:
       - default | bool
       - nodejs_version == '--lts'
       changed_when: "'nodejs_version' not in mg_nvm_default_response.stdout"
@@ -267,5 +267,5 @@
       loop:
         "{{ nvm_commands }}"
       when: nvm_commands | length > 0
-      
+
   when: not uninstall


### PR DESCRIPTION
The NVM install script requires *bash* to run successfully. 
If you try to use another shell like *zsh*, you will get this error message:

```
wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.39.7/install.sh | zsh
Error: the install instructions explicitly say to pipe the install script to `bash`; please follow them
```

This pull request fulfills this requirement.